### PR TITLE
Chore: migration watchtower vers fork maintenu + stratégie d’auto-update en opt-in

### DIFF
--- a/WATCHTOWER_SCOPE_LABELS_EXPLICATION.md
+++ b/WATCHTOWER_SCOPE_LABELS_EXPLICATION.md
@@ -1,0 +1,28 @@
+# Watchtower: scope vs enable
+
+Cette note explique le comportement quand `WATCHTOWER_SCOPE` et `WATCHTOWER_LABEL_ENABLE=true` sont utilisés ensemble.
+
+## Ce que fait `WATCHTOWER_SCOPE`
+
+- Le scope (`item-watchtower-scope`) définit le périmètre de conteneurs que cette instance watchtower peut considérer.
+- Un conteneur hors scope est ignoré.
+
+## Ce que fait `WATCHTOWER_LABEL_ENABLE=true`
+
+- Ce mode active une logique "opt-in".
+- Dans le scope, watchtower ne met à jour automatiquement que les conteneurs avec:
+  - `com.centurylinklabs.watchtower.enable=true`
+- Les conteneurs marqués `enable=false` (ou sans label `enable=true`) ne sont pas auto-mis à jour.
+
+## Implication pour les services exclus
+
+Pour `item-db`, `item-db-adminer`, `item-db-dumper` (et `item-watchtower`), marqués `enable=false`:
+
+- Pas de `pull` automatique.
+- Pas de redémarrage automatique lié à watchtower.
+- Mise à jour uniquement manuelle (`docker compose pull ...` puis `docker compose up -d ...`).
+
+## Résumé
+
+- `scope` = quels conteneurs sont visibles par watchtower.
+- `enable=true/false` = parmi ceux visibles, lesquels sont autorisés à l'auto-update.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - "co.elastic.logs/processors.add_fields.fields.abes_middleware=nginx"
       # pour que les mises à jour de cette image soient auto-déployées par watchtower
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=true"
 
 
 
@@ -95,6 +96,7 @@ services:
       - "co.elastic.logs/processors.add_fields.fields.abes_middleware=java-spring"
       # pour que les mises à jour de cette image soient auto-déployées par watchtower
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=true"
 
 
   item-batch:
@@ -146,6 +148,7 @@ services:
       - "co.elastic.logs/processors.add_fields.fields.abes_middleware=java-spring"
       # pour que les mises à jour de cette image soient auto-déployées par watchtower
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=true"
 
 
 
@@ -183,8 +186,9 @@ services:
       - "co.elastic.logs/processors.add_fields.target="
       - "co.elastic.logs/processors.add_fields.fields.abes_appli=item"
       - "co.elastic.logs/processors.add_fields.fields.abes_middleware=postgresql"
-      # pour que les mises à jour de cette image soient auto-déployées par watchtower
+      # exclut la base de données des mises à jour automatiques watchtower
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=false"
 
 
   #################################
@@ -205,8 +209,9 @@ services:
     logging:
       driver: none # pas de log pour adminer pour ne pas polluer
     labels:
-      # pour que les mises à jour de cette image soient auto-déployées par watchtower
+      # exclut adminer des mises à jour automatiques watchtower
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=false"
 
 
 
@@ -263,8 +268,9 @@ services:
       - "co.elastic.logs/multiline.pattern='^.*Dumping PostgresSQL database'"
       - "co.elastic.logs/multiline.negate=true"
       - "co.elastic.logs/multiline.match=after"
-      # pour que les mises à jour de cette image soient auto-déployées par watchtower
+      # exclut le dumper des mises à jour automatiques watchtower
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=false"
 
 
 
@@ -294,10 +300,12 @@ services:
       WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER: ${ITEM_WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER}
       WATCHTOWER_NOTIFICATION_SLACK_CHANNEL: "#notif-item"
       WATCHTOWER_SCOPE: "item-watchtower-scope"
+      WATCHTOWER_LABEL_ENABLE: "true"
       REPO_USER: ${ITEM_WATCHTOWER_DOCKERHUB_USER}
       REPO_PASS: ${ITEM_WATCHTOWER_DOCKERHUB_PASS}
     labels:
       - "com.centurylinklabs.watchtower.scope=item-watchtower-scope"
+      - "com.centurylinklabs.watchtower.enable=false"
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,7 @@ services:
   # plus d'info : https://containrrr.dev/watchtower
   # cf README.md pour explications : https://github.com/abes-esr/item-docker#d%C3%A9ploiement-continu
   item-watchtower:
-    image: containrrr/watchtower:1.4.0
+    image: nickfedor/watchtower:1.14.1
     container_name: item-watchtower
     restart: unless-stopped
     mem_limit: ${MEM_LIMIT}


### PR DESCRIPTION
Cette PR migre la stratégie Watchtower de item-docker pour fiabiliser les mises à jour automatiques.

  Actions réalisées :

  1. Remplacement de l’image Watchtower archivée
      - containrrr/watchtower:1.4.0 -> nickfedor/watchtower:1.14.1
  2. Activation du mode opt-in par labels
      - ajout de WATCHTOWER_LABEL_ENABLE=true sur item-watchtower
  3. Sélection explicite des services auto-updatés
      - enable=true : item-front, item-api, item-batch
      - enable=false : item-db, item-db-adminer, item-db-dumper, item-watchtower
  4. Conservation du scope existant
      - WATCHTOWER_SCOPE=item-watchtower-scope inchangé
  5. Ajout d’une note de documentation
      - WATCHTOWER_SCOPE_LABELS_EXPLICATION.md (explication claire scope vs enable)

  Impact attendu :

  - Réduction du risque opérationnel sur les services sensibles (DB/dumper).
  - Auto-update limité aux services applicatifs souhaités.
  - Comportement Watchtower plus prévisible et explicite.